### PR TITLE
GH Actions fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,8 @@ jobs:
         run: |
           Rscript -e "install.packages('remotes')"
           Rscript -e "remotes::install_deps(dependencies = TRUE)"
-          Rscript -e "remotes::install_cran('rcmdcheck')"
+      - name: Install check tools
+        run: Rscript -e "remotes::install_cran('rcmdcheck')"
       - name: R session info # sessioninfo is a reverse dep of {{rcmdcheck}}
         run: Rscript -e "sessioninfo::platform_info()"
       - name: Check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,16 +18,16 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       CRAN: ${{ matrix.config.cran }}
-      # TZ: "UTC"   # seems to be a bug in r-lib/actions setting TZ on Windows
+      TZ: "UTC"   # seems to be a bug in r-lib/actions setting TZ on Windows
     steps:
       - name: Check out repo
         uses: actions/checkout@v1
-      - name: Set timezone on Windows
-        if: matrix.config.os == 'windows-latest'
-        run: | # seems to be a bug in r-lib/actions setting TZ on Windows
-           tzutil /g
-           tzutil /s "GMT Standard Time"
-           tzutil /g
+      #- name: Set timezone on Windows
+      #  if: matrix.config.os == 'windows-latest'
+      #  run: | # seems to be a bug in r-lib/actions setting TZ on Windows
+      #     tzutil /g
+      #     tzutil /s "GMT Standard Time"
+      #     tzutil /g
       - name: Setup R
         uses: r-lib/actions/setup-r@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,16 +18,9 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       CRAN: ${{ matrix.config.cran }}
-      TZ: "UTC"   # seems to be a bug in r-lib/actions setting TZ on Windows
     steps:
       - name: Check out repo
         uses: actions/checkout@v1
-      #- name: Set timezone on Windows
-      #  if: matrix.config.os == 'windows-latest'
-      #  run: | # seems to be a bug in r-lib/actions setting TZ on Windows
-      #     tzutil /g
-      #     tzutil /s "GMT Standard Time"
-      #     tzutil /g
       - name: Setup R
         uses: r-lib/actions/setup-r@master
         with:


### PR DESCRIPTION
Changes proposed:

- Remove need to manually set Windows timezone. See https://github.com/r-lib/actions/issues/12
- Move installing of `rcmdcheck` to separate work step. Closes https://github.com/r-lib/actions/issues/14