### PR TITLE
Fix London holiday checker

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: fmdates
 Title: Financial Market Date Calculations
-Version: 0.1.4
+Version: 0.1.4-99
 Authors@R: person("Imanuel", "Costigan", email = "i.costigan@me.com", 
                   role = c("aut", "cre"))
 Description: Implements common date calculations relevant for specifying

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 Changes in version 0.1.5
 
-- Fixed substitution logic for `GBLOCalendar()` for Boxing Day (#17)
+For London calendar:
+
+- Early May Day bank holiday moved to align to VE Day (#14)
+- Boxing Day substitution fixed for London (#17)
+- Fixed hidden bank day bug
 
 Changes in version 0.1.4
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Changes in version 0.1.5
+
+- Fixed substitution logic for `GBLOCalendar()` for Boxing Day (#17)
+
 Changes in version 0.1.4
 
 - `is_good()` no longer relies on `lubridate::wday()` abbreviations (#9)

--- a/R/calendar-methods.R
+++ b/R/calendar-methods.R
@@ -178,21 +178,23 @@ is_good.GBLOCalendar <- function(dates, calendar) {
       # Easter
       a$doy == a$em | a$doy == a$em - 3 |
       #### Bank day
-      # May Day bank holiday. First Mon of May. 2002/2012 spring hol moved 4 Jun.
-      ((a$dom <= 7 & a$m == 5 & a$dow == 1 & a$y >= 1978 &
-          (a$y != 2002 | a$y != 2012)) |
-          (a$dom == 4 & a$m == 6 & (a$y == 2002 | a$y == 2012)) |
-          # Spring bank hol. Last Mon of May (excl. 2002, 2012)
-          (a$dom > 24 & a$m == 5 & a$dow == 1 &
-              (a$y >= 1971 & a$y != 2002 & a$y != 2012)) |
-          # Spring bank holiday pushed back to 4 June for Queen's Golden and Diamond
-          # Jubilee
-          (a$dom == 4 & a$m == 6 & (a$y == 2002 | a$y == 2012)) |
-          # Late summer bank hol. Last Mon of Aug.
-          (a$dom > 24 & a$m == 8 & a$dow == 1 & a$y >= 1971)) |
-      ####
+      # Early May Day bank holiday. First Mon of May. Except:
+      # 2020 moved to 8 May to align with VE day commemoration
+      (a$dom <= 7 & a$m == 5 & a$dow == 1 & (a$y >= 1978 & a$y != 2020)) |
+      # Early May Day moved to align to VE day in 2020
+      (a$dom == 8 & a$m == 5 & a$y >= 1978 & a$y == 2020) |
+      # Spring bank hol. Last Mon of May. Except: 2002/2012 spring hol moved
+      # forward to align to Queen's Jubilee.
+      (a$dom > 24 & a$m == 5 & a$dow == 1 &
+          (a$y >= 1971 & a$y != 2002 & a$y != 2012)) |
+      # Spring bank holiday pushed back to 4 June for Queen's Jubilee
+      (a$dom == 4 & a$m == 6 & a$y >= 1978 & (a$y == 2002 | a$y == 2012)) |
       # Queen's Jubilee
+      a$dom == 8 & a$m == 6 & a$y == 2002 |
       a$dom == 5 & a$m == 6 & a$y == 2012 |
+      # Late summer bank hol. Last Mon of Aug.
+      (a$dom > 24 & a$m == 8 & a$dow == 1 & a$y >= 1971) |
+      ####
       # Christmas. Substitute generally given
       ((a$dom == 25 | (a$dom == 27 & (a$dow == 1 | a$dow == 2))) & a$m == 12) |
       # Boxing Day. Substitute generally given

--- a/R/calendar-methods.R
+++ b/R/calendar-methods.R
@@ -193,12 +193,10 @@ is_good.GBLOCalendar <- function(dates, calendar) {
       ####
       # Queen's Jubilee
       a$dom == 5 & a$m == 6 & a$y == 2012 |
-      # Christmas
-      a$dom == 25 & a$m == 12 |
-      # Boxing Day. 26th December, if not a Sun.
-      # 27th December in a year in which 25th or 26th December is a Sunday
-      ((a$dom == 26 | (a$dom == 27 & (a$dow == 1 |
-          a$dow == 2))) & a$m == 12) |
+      # Christmas. Substitute generally given
+      ((a$dom == 25 | (a$dom == 27 & (a$dow == 1 | a$dow == 2))) & a$m == 12) |
+      # Boxing Day. Substitute generally given
+      ((a$dom == 26 | (a$dom == 28 & (a$dow == 1 | a$dow == 2))) & a$m == 12) |
       # Royal Wedding
       a$dom == 29 & a$m == 4 & a$y == 2011)
 }

--- a/tests/testthat/test-calendars.R
+++ b/tests/testthat/test-calendars.R
@@ -97,11 +97,14 @@ test_that('London calendar is correct', {
     20120605, 20120827, 20121225, 20121226)
   hol_2013 <- ymd(20130101, 20130329, 20130401, 20130506, 20130527, 20130826,
     20131225, 20131226)
+  hol_boxing_day_sub <- ymd(20201228, 20211228)
 
   # Check bad days are bad
   gblo <- GBLOCalendar()
   expect_identical(is_good(hol_2012, gblo), rep(FALSE, NROW(hol_2012)))
   expect_identical(is_good(hol_2013, gblo), rep(FALSE, NROW(hol_2013)))
+  expect_identical(is_good(hol_boxing_day_sub, gblo),
+    rep(FALSE, NROW(hol_boxing_day_sub)))
 
   # Check weekends bad
   expect_equal(is_good(ymd(20150214, 20150215),gblo), c(FALSE, FALSE))

--- a/tests/testthat/test-calendars.R
+++ b/tests/testthat/test-calendars.R
@@ -98,6 +98,7 @@ test_that('London calendar is correct', {
   hol_2013 <- ymd(20130101, 20130329, 20130401, 20130506, 20130527, 20130826,
     20131225, 20131226)
   hol_boxing_day_sub <- ymd(20201228, 20211228)
+  hol_mayday_2020 <- ymd(20200504, 20200508)
 
   # Check bad days are bad
   gblo <- GBLOCalendar()
@@ -105,6 +106,7 @@ test_that('London calendar is correct', {
   expect_identical(is_good(hol_2013, gblo), rep(FALSE, NROW(hol_2013)))
   expect_identical(is_good(hol_boxing_day_sub, gblo),
     rep(FALSE, NROW(hol_boxing_day_sub)))
+  expect_identical(is_good(hol_mayday_2020[2], gblo), FALSE)
 
   # Check weekends bad
   expect_equal(is_good(ymd(20150214, 20150215),gblo), c(FALSE, FALSE))
@@ -116,6 +118,7 @@ test_that('London calendar is correct', {
   bd2013 <- bd2013[!(wday(bd2013) %in% c(1, 7))]
   expect_identical(is_good(bd2012, gblo), rep(TRUE, NROW(bd2012)))
   expect_identical(is_good(bd2013, gblo), rep(TRUE, NROW(bd2013)))
+  expect_identical(is_good(hol_mayday_2020[1], gblo), TRUE)
 })
 
 test_that('TARGET calendar is correct', {


### PR DESCRIPTION
Fixes #14 and #17

Changes proposed for `is_good.GBLOCalendar()`:

- Early May Day bank holiday moved to align to VE Day (#14)
- Boxing Day substitution fixed for London (#17)
- Fixed hidden bank day bug
- Updated NEWS and DESCRIPTION files
